### PR TITLE
V 1.96y Fix screen brightness not saving 

### DIFF
--- a/Settings/main.qml
+++ b/Settings/main.qml
@@ -597,7 +597,7 @@ Rectangle {
                     Component.onCompleted: tabView.currentIndex = 1 // opens the 2nd tab
                 }
                 Text {
-                    text: " V 1.96x " + Dashboard.Platform
+                    text: " V 1.96y " + Dashboard.Platform
                     color: "white"
                     font.pixelSize: windowbackround.width / 55
                 } //spacer

--- a/appsettings.cpp
+++ b/appsettings.cpp
@@ -270,6 +270,14 @@ void AppSettings::writeTrackSettings(const QString &Track)
     m_dashboard->setCBXTracksave(Track);
 
 }
+
+void AppSettings::writebrightnessettings(const int &Brightness)
+{
+    setValue("Brightness", Brightness);
+    m_dashboard->setBrightness(Brightness);
+
+}
+
 void AppSettings::writeStartupSettings(const int &ExternalSpeed)
 {
     setValue("ExternalSpeed", ExternalSpeed);
@@ -305,5 +313,6 @@ void AppSettings::readandApplySettings()
     m_dashboard->setExternalSpeed(getValue("ExternalSpeed").toInt());
     m_dashboard->setCBXCountrysave(getValue("Country").toString());
     m_dashboard->setCBXTracksave(getValue("Track").toString());
+    m_dashboard->setBrightness(getValue("Brightness").toInt());
 }
 

--- a/appsettings.cpp
+++ b/appsettings.cpp
@@ -1,6 +1,6 @@
-#include "appsettings.h"
 #include <QSettings>
 #include <QDebug>
+#include "appsettings.h"
 #include "dashboard.h"
 
 AppSettings::AppSettings(QObject *parent)
@@ -94,7 +94,6 @@ void AppSettings::setInterface(const int &arg)
 int AppSettings::getLogging()
 {
     return getValue("serial/Logging").toInt();
-
 }
 
 void AppSettings::setLogging(const int &arg)
@@ -121,7 +120,6 @@ void AppSettings::writeSelectedDashSettings(int numberofdashes)
 {
      setValue("Number of Dashes", numberofdashes);
      // To be implemented later
-
 }
 
 void AppSettings::writeWarnGearSettings(const qreal &waterwarn,const qreal &boostwarn,const qreal &rpmwarn,const qreal &knockwarn,const int &gercalactive,const qreal&lambdamultiply,const qreal &valgear1,const qreal &valgear2,const qreal &valgear3,const qreal &valgear4,const qreal &valgear5,const qreal &valgear6)

--- a/appsettings.h
+++ b/appsettings.h
@@ -43,6 +43,7 @@ public:
     Q_INVOKABLE void writeCylinderSettings(const qreal &Cylinders);
     Q_INVOKABLE void writeCountrySettings(const QString &Country);
     Q_INVOKABLE void writeTrackSettings(const QString &Track);
+    Q_INVOKABLE void writebrightnessettings(const int &Brightness);
     Q_INVOKABLE void writeStartupSettings(const int &ExternalSpeed);
     Q_INVOKABLE void readandApplySettings();
 

--- a/main.qml
+++ b/main.qml
@@ -12,14 +12,14 @@ ApplicationWindow {
     minimumHeight: 480
     title: qsTr("PowerTune ") + Dashboard.Platform
     color: "black"
-/*
+
     Connections{
             target: Dashboard
             onBrigtnessChanged: {
             brightness.value = Dashboard.Brightness
             }
     }
-*/
+
     Item {
         id: name
         Component.onCompleted: Connect.checkifraspberrypi()
@@ -166,7 +166,10 @@ ApplicationWindow {
             from: 20
             to: 255
             value: Dashboard.Brightness
-            onMoved: Connect.setSreenbrightness(brightness.value);
+            onValueChanged: {
+                     Connect.setSreenbrightness(brightness.value);
+                     AppSettings.writebrightnessettings(brightness.value);
+                     }
             //Component.onCompleted: Connect.setSreenbrightness(brightness.value);
         }
     }

--- a/main.qml
+++ b/main.qml
@@ -12,13 +12,14 @@ ApplicationWindow {
     minimumHeight: 480
     title: qsTr("PowerTune ") + Dashboard.Platform
     color: "black"
-
+/*
     Connections{
             target: Dashboard
             onBrigtnessChanged: {
             brightness.value = Dashboard.Brightness
             }
     }
+*/
     Item {
         id: name
         Component.onCompleted: Connect.checkifraspberrypi()
@@ -164,10 +165,9 @@ ApplicationWindow {
             stepSize: 5
             from: 20
             to: 255
-            //visible: Dashboard.screen
             value: Dashboard.Brightness
+            onMoved: Connect.setSreenbrightness(brightness.value);
             //Component.onCompleted: Connect.setSreenbrightness(brightness.value);
-            onPositionChanged: Connect.setSreenbrightness(brightness.value);
         }
     }
     }


### PR DESCRIPTION
Screen brightness didn't save if dash was not shutdown properly.
Changed the way how screen brightness is initialized .