### PR TITLE
Show and Evaluate HDOP

### DIFF
--- a/Gauges/GPS.qml
+++ b/Gauges/GPS.qml
@@ -113,7 +113,7 @@ Rectangle {
             onCurrentIndexChanged: changetrack.change()
         }
         Grid {
-            rows: 8
+            rows: 10
             columns: 2
             spacing: 5
             anchors.left: map.right
@@ -204,6 +204,18 @@ Rectangle {
                 font.family: "Eurostile"
             }
             Text {
+                text: "GPS HDOP: "
+                font.pixelSize: 20
+                font.bold: true
+                font.family: "Eurostile"
+            }
+            Text {
+                text: (Dashboard.gpsHDOP).toFixed(2)
+                font.pixelSize: 20
+                font.bold: true
+                font.family: "Eurostile"
+            }
+            Text {
                 text: "GPS FIX type: "
                 font.pixelSize: 20
                 font.bold: true
@@ -215,6 +227,7 @@ Rectangle {
                 font.bold: true
                 font.family: "Eurostile"
             }
+
         }
 
         Item {

--- a/dashboard.cpp
+++ b/dashboard.cpp
@@ -4,9 +4,6 @@
 #include <QVector>
 #include "math.h"
 
-////
-
-
 
 QVector<int>averageSpeed(0);
 QVector<int>averageRPM(0);
@@ -271,6 +268,7 @@ DashBoard::DashBoard(QObject *parent)
     , m_gpsVisibleSatelites (0)
     , m_gpsFIXtype ("no connection")
     , m_gpsbearing (0)
+    , m_gpsHDOP (0)
 
 
     //units
@@ -798,7 +796,7 @@ void DashBoard::setIntakepress(const qreal &Intakepress)
     {m_Intakepress = Intakepress;}
     if (m_pressureunits == "imperial")
     {m_Intakepress = Intakepress * 0.145038;}
-    emit intakepressChanged(Intakepress);    
+    emit intakepressChanged(Intakepress);
     return;
 }
 
@@ -1830,6 +1828,13 @@ void DashBoard::setgpsbearing(const qreal &gpsbearing)
     emit gpsbearingChanged(gpsbearing);
 }
 
+void DashBoard::setgpsHDOP(const qreal &gpsHDOP)
+{
+    if (m_gpsHDOP == gpsHDOP)
+        return;
+    m_gpsHDOP = gpsHDOP;
+    emit gpsHDOPChanged(gpsHDOP);
+}
 
 // Units
 void DashBoard::setunits (const QString &units)
@@ -3623,7 +3628,6 @@ void DashBoard::setEXAnalogInput0(const qreal &EXAnalogInput0)
   * Is our Sensor thats connected to 5V and PIN 24
   * R2 is fixed
   * R3 is user Selectable ( 100 /1000 Ohm or no resistor)
-
                   |  Vin (+5V)
                   |
                  | |
@@ -3647,7 +3651,6 @@ void DashBoard::setEXAnalogInput0(const qreal &EXAnalogInput0)
                 -----   GND
                  ---
                   -
-
 We already know the Values of Rw and R3 as well as Vin , now we need to calculate the Resistance of the sensor R1
 */
     //Calculate the resistance of a potential NTC at the Analog Input Whereby input voltage is 5V
@@ -4819,8 +4822,7 @@ double DashBoard::gpsSpeed() const { return m_gpsSpeed; }
 int DashBoard::gpsVisibleSatelites () const { return m_gpsVisibleSatelites; }
 QString DashBoard::gpsFIXtype () const { return m_gpsFIXtype; }
 qreal DashBoard::gpsbearing() const { return m_gpsbearing; }
-
-
+qreal DashBoard::gpsHDOP() const { return m_gpsHDOP; }
 
 //units
 QString DashBoard::units() const { return m_units; }
@@ -5208,5 +5210,3 @@ qreal DashBoard::activeboosttable() const {return m_activeboosttable;}
 qreal DashBoard::activetunetable() const {return m_activetunetable;}
 qreal DashBoard::genericoutput1() const {return m_genericoutput1;}
 qreal DashBoard::frequencyDIEX1() const {return m_frequencyDIEX1;}
-
-

--- a/dashboard.h
+++ b/dashboard.h
@@ -215,6 +215,7 @@ class DashBoard : public QObject
     Q_PROPERTY(int gpsVisibleSatelites READ gpsVisibleSatelites WRITE setgpsVisibleSatelites NOTIFY gpsVisibleSatelitesChanged)
     Q_PROPERTY(QString gpsFIXtype READ gpsFIXtype  WRITE setgpsFIXtype  NOTIFY gpsFIXtypeChanged)
     Q_PROPERTY(qreal gpsbearing READ gpsbearing WRITE setgpsbearing NOTIFY gpsbearingChanged)
+    Q_PROPERTY(qreal gpsHDOP READ gpsHDOP WRITE setgpsHDOP NOTIFY gpsHDOPChanged)
 
     //Units ( metric /imperial select
     Q_PROPERTY(QString units READ units WRITE setunits NOTIFY unitsChanged)
@@ -760,6 +761,7 @@ class DashBoard : public QObject
     void setgpsVisibleSatelites(const int &gpsVisibleSatelites);
     void setgpsFIXtype(const QString &gpsFIXtype);
     void setgpsbearing(const qreal &gpsbearing);
+    void setgpsHDOP(const qreal &gpsHDOP);
 
     // Units
     void setunits(const QString &units);
@@ -1320,6 +1322,7 @@ class DashBoard : public QObject
     int gpsVisibleSatelites() const;
     QString gpsFIXtype() const;
     qreal gpsbearing() const;
+    qreal gpsHDOP() const;
 
     //units
     QString units() const;
@@ -1875,6 +1878,7 @@ signals:
     void gpsVisibleSatelitesChanged(int gpsVisibleSatelites);
     void gpsFIXtypeChanged(QString gpsFIXtype);
     void gpsbearingChanged(qreal gpsbearing);
+    void gpsHDOPChanged(qreal gpsHDOP);
 
     // units
 
@@ -2425,7 +2429,7 @@ private:
     qreal m_PANVAC;
     qreal m_MAP2;
     qreal m_AUXT;
-    qreal m_AFR;  
+    qreal m_AFR;
     qreal m_AFRLEFTBANKTARGET;
     qreal m_AFRRIGHTBANKTARGET;
     //
@@ -2481,6 +2485,7 @@ private:
     int m_gpsVisibleSatelites;
     QString m_gpsFIXtype;
     qreal m_gpsbearing;
+    qreal m_gpsHDOP;
 
     //Units
 

--- a/gps.cpp
+++ b/gps.cpp
@@ -11,6 +11,7 @@ int initialized = 0;
 int rateset = 0;
 int raterequ = 0;
 int baudrate;
+float hdop;
 QString GPSPort;
 QTime fastestlap(0, 0);
 QByteArray ACK10HZ = QByteArray::fromHex("b562050102000608");
@@ -297,7 +298,10 @@ void GPS::processGPRMC(const QString & line) {
     {
     m_dashboard->setgpsLatitude(decLat.toDouble());
     m_dashboard->setgpsLongitude(decLon.toDouble());
-    m_dashboard->setgpsSpeed(qRound(speed));  // round speed to the nearest integer
+    if ((hdop >= 20) || (speed >= 15))           // This avoids that the GPS speed fluctuates when standing and hdop is low
+       {
+       m_dashboard->setgpsSpeed(qRound(speed));  // round speed to the nearest integer
+       }
     checknewLap();
     }
     m_dashboard->setgpsTime(time);
@@ -307,6 +311,8 @@ void GPS::processGPGGA(const QString & line)
 {
     QStringList fields = line.split(',');
     int fixquality = fields[6].toInt();
+    hdop = fields[8].toFloat();
+    m_dashboard->setgpsHDOP(hdop);
 
     switch (fixquality) {
     case 0:


### PR DESCRIPTION
Evaluate HDOP 
Show HDOP in GPS Dash
Only show GPS Speed if HDOP is greater 20 or Speed is greater 15 Km/h (This ensures the speed does not bounce when stationary )