### PR TITLE
Use float to manipulate latitude/longitude

### DIFF
--- a/Gauges/GPS.qml
+++ b/Gauges/GPS.qml
@@ -162,7 +162,7 @@ Rectangle {
                 font.family: "Eurostile"
             }
             Text {
-                text: Dashboard.gpsLatitude
+                text: Dashboard.gpsLatitude.toFixed(6)
                 font.pixelSize: 20
                 font.bold: true
                 font.family: "Eurostile"
@@ -174,7 +174,7 @@ Rectangle {
                 font.family: "Eurostile"
             }
             Text {
-                text: Dashboard.gpsLongitude
+                text: Dashboard.gpsLongitude.toFixed(6)
                 font.pixelSize: 20
                 font.bold: true
                 font.family: "Eurostile"

--- a/gps.cpp
+++ b/gps.cpp
@@ -307,13 +307,13 @@ void GPS::processGPRMC(const QString & line) {
 
     double speed = groundspeedknots.toDouble() * 1.852;
 
-    QString decLat = convertToDecimal(latitude, latDirection);
-    QString decLon = convertToDecimal(longitude, lonDirection);
+    float decLat = convertToFloat(latitude, latDirection);
+    float decLon = convertToFloat(longitude, lonDirection);
 
     if ((m_dashboard->gpsFIXtype() == "GPS only") ||(m_dashboard->gpsFIXtype() == "DGPS") )
     {
-    m_dashboard->setgpsLatitude(decLat.toDouble());
-    m_dashboard->setgpsLongitude(decLon.toDouble());
+    m_dashboard->setgpsLatitude(decLat);
+    m_dashboard->setgpsLongitude(decLon);
   //  if ((hdop >= 20) || (speed >= 20))           // This avoids that the GPS speed fluctuates when standing and hdop is low
   //     {
        m_dashboard->setgpsSpeed(qRound(speed));  // round speed to the nearest integer
@@ -348,15 +348,15 @@ void GPS::processGPGGA(const QString & line)
     QString latDirection = fields[3];
     QString longitude = fields[4];
     QString lonDirection = fields[5];
-    QString decLat = convertToDecimal(latitude, latDirection);
-    QString decLon = convertToDecimal(longitude, lonDirection);
+    float decLat = convertToFloat(latitude, latDirection);
+    float decLon = convertToFloat(longitude, lonDirection);
 
     QString satelitesinview = fields[7];
     QString altitude = fields[9];
     if ((m_dashboard->gpsFIXtype() == "GPS only") ||(m_dashboard->gpsFIXtype() == "DGPS") )
     {
-    m_dashboard->setgpsLatitude(decLat.toDouble());
-    m_dashboard->setgpsLongitude(decLon.toDouble());
+    m_dashboard->setgpsLatitude(decLat);
+    m_dashboard->setgpsLongitude(decLon);
     m_dashboard->setgpsAltitude(altitude.toDouble());
     checknewLap();
     }
@@ -369,19 +369,19 @@ void GPS::processGPVTG(const QString & line)
     QString speed = fields[7];
     // m_dashboard->setgpsSpeed(speed.toInt());
 }
-QString GPS::convertToDecimal(const QString & coord, const QString & dir)
+
+float GPS::convertToFloat(const QString & coord, const QString & dir)
 {
     int decIndex = coord.indexOf('.');
     QString minutes = coord.mid(decIndex- 2);
     QString seconds = coord.mid(decIndex+1, 2);
-    double dec = minutes.toDouble() * 60 / 3600;
-    double degrees = coord.mid(0, decIndex -2).toDouble();
-    double decCoord = dec + degrees;
+    float dec = minutes.toDouble() * 60 / 3600;
+    float degrees = coord.mid(0, decIndex -2).toDouble();
+    float decCoord = dec + degrees;
     if (dir == "W" || dir == "S")
         decCoord *= -1.0;
-    return QString::number(decCoord, 'f', 6);
+    return decCoord;
 }
-
 
 // Laptimer
 void GPS::defineFinishLine(const qreal & Y1, const qreal & X1, const qreal & Y2, const qreal & X2)

--- a/gps.cpp
+++ b/gps.cpp
@@ -293,10 +293,10 @@ void GPS::processGPRMC(const QString & line) {
     QString time = fields[1];
     time.insert(2, ":");
     time.insert(5, ":");
-    QString latitude = fields[3];
-    QString latDirection = fields[4];
-    QString longitude = fields[5];
-    QString lonDirection = fields[6];
+
+    float decLat = convertToFloat(fields[3], fields[4]);
+    float decLon = convertToFloat(fields[5], fields[6]);
+
     QString groundspeedknots = fields[7];
     QString bearing = fields[8];
     if (bearing != "")
@@ -307,8 +307,6 @@ void GPS::processGPRMC(const QString & line) {
 
     double speed = groundspeedknots.toDouble() * 1.852;
 
-    float decLat = convertToFloat(latitude, latDirection);
-    float decLon = convertToFloat(longitude, lonDirection);
 
     if ((m_dashboard->gpsFIXtype() == "GPS only") ||(m_dashboard->gpsFIXtype() == "DGPS") )
     {
@@ -344,12 +342,9 @@ void GPS::processGPGGA(const QString & line)
         m_dashboard->setgpsFIXtype("No fix yet");
         break;
     }
-    QString latitude = fields[2];
-    QString latDirection = fields[3];
-    QString longitude = fields[4];
-    QString lonDirection = fields[5];
-    float decLat = convertToFloat(latitude, latDirection);
-    float decLon = convertToFloat(longitude, lonDirection);
+
+    float decLat = convertToFloat(fields[2], fields[3]);
+    float decLon = convertToFloat(fields[4], fields[5]);
 
     QString satelitesinview = fields[7];
     QString altitude = fields[9];

--- a/gps.h
+++ b/gps.h
@@ -27,7 +27,7 @@ class GPS : public QObject
     QElapsedTimer m_timer;
     QTimer m_timeouttimer;
     QTimer m_reconnecttimer;
-    QString convertToDecimal(const QString & coord, const QString & dir);
+    float convertToFloat(const QString & coord, const QString & dir);
     void processGPRMC(const QString &line);
     void checklinecrossed();
     void linecrossed();


### PR DESCRIPTION
The previous code was doing qstring to double conversion, then converting the values back to qstring for storage/usage.
Using float here makes more sense, is more memory efficient, and according to the benchmark below is also quite faster than manipulating strings.

This also opens up possibilities to leverage signal/slots for consumers of gps updates, like the laptimer or the telemetry without having to call their handlers explicitly (like we do with `checknewLap();` currently, where the laptracker could actually be inactive).

Benchmark results:
```
0.785383
Time elapsed (100000 x new): 142 ms
0.785383
Time elapsed (100000 x old): 273 ms
```

Benchmark code:
```c++
#include <QTextStream>
#include <QElapsedTimer>

float convertToFloat(const QString & coord, const QString & dir)
{
    int decIndex = coord.indexOf('.');
    QString minutes = coord.mid(decIndex- 2);
    QString seconds = coord.mid(decIndex+1, 2);
    float dec = minutes.toDouble() * 60 / 3600;
    float degrees = coord.mid(0, decIndex -2).toDouble();
    float decCoord = dec + degrees;
    if (dir == "W" || dir == "S")
        decCoord *= -1.0;
    return decCoord;
}

QString convertToDecimal(const QString & coord, const QString & dir)
{
    int decIndex = coord.indexOf('.');
    QString minutes = coord.mid(decIndex- 2);
    QString seconds = coord.mid(decIndex+1, 2);
    double dec = minutes.toDouble() * 60 / 3600;
    double degrees = coord.mid(0, decIndex -2).toDouble();
    double decCoord = dec + degrees;
    if (dir == "W" || dir == "S")
        decCoord *= -1.0;
    return QString::number(decCoord, 'f', 6);
}

int main() {

    int nb_runs = 100000;

    QElapsedTimer timer;
    timer.start();
    float latf;
    for (int i = 0; i < nb_runs; i++) {
        latf = convertToFloat("47.123", "N");
    }
    QTextStream(stdout) << latf << endl;
    QTextStream(stdout) << "Time elapsed ("<< nb_runs << " x new): " << timer.elapsed() << " ms" << endl;
    
    
    timer.start();
    QString lats;
    for (int i = 0; i < nb_runs; i++) {
        lats =convertToDecimal("47.123", "N");
    }
    
    QTextStream(stdout) << lats << endl;
    QTextStream(stdout) << "Time elapsed ("<< nb_runs << " x old): " << timer.elapsed() << " ms" << endl;
 
    return 0;
}

```