### PR TITLE
Simplified closeConnection() calls

### DIFF
--- a/gps.cpp
+++ b/gps.cpp
@@ -127,7 +127,9 @@ void GPS::setGPSBAUD115()
     m_dashboard->setgpsFIXtype("GPS set 115k");
     m_serialport->write(QByteArray::fromHex("B5620600140001000000D008000000C201000700020000000000BF78"));
     m_serialport->waitForBytesWritten(4000);
-    closeConnection1();
+    closeConnection();
+    initialized = 1;
+    openConnection(GPSPort, "115200");
 }
 void GPS::setGPS10HZ()
 {
@@ -151,19 +153,6 @@ void GPS::closeConnection()
     disconnect(&m_reconnecttimer, &QTimer::timeout, this, &GPS::handleReconnectTimeout);
     m_serialport->close();
     m_dashboard->setgpsFIXtype("close serial");
-}
-void GPS::closeConnection1()
-{
-    m_dashboard->setgpsFIXtype("close connection");
-    disconnect(this->m_serialport, SIGNAL(readyRead()), this, SLOT(readyToRead()));
-    disconnect(m_serialport, static_cast<void (QSerialPort::*)(QSerialPort::SerialPortError)>(&QSerialPort::error),
-               this, &GPS::handleError);
-    disconnect(&m_timeouttimer, &QTimer::timeout, this, &GPS::handleTimeout);
-    disconnect(&m_reconnecttimer, &QTimer::timeout, this, &GPS::handleReconnectTimeout);
-    m_serialport->close();
-    initialized = 1;
-    m_dashboard->setgpsFIXtype("close serial");
-    openConnection(GPSPort, "115200");
 }
 
 void GPS::handleError(QSerialPort::SerialPortError serialPortError)

--- a/gps.h
+++ b/gps.h
@@ -46,7 +46,6 @@ class GPS : public QObject
     void setGPS10HZ();
     void setGPSOnly();
     void closeConnection();
-    void closeConnection1();
     void clear();
 
  private slots:


### PR DESCRIPTION
The `closeConnection1()` code is merely a duplicate of `closeConnection()` with just 2 extra calls.
This function was called only in one place, after setting the baudrate of the gps device in order to force a re-opening of the serial connection with the newly set baudrate. 

If we move the initialized flag and reopen the connection from where we make that call, we avoid the need for this duplicated code meaning that we are guaranteed to have to maintain only one code path to handle closing serial connections.