### PR TITLE
Keyboardglitchqt515

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -15,7 +15,7 @@ ApplicationWindow {
     title: qsTr("PowerTune ") + Dashboard.Platform
     color: "black"
 
-    //Screen Keyboard do not change !!!
+    //Screen Keyboard do not change !!! Behaviour between QT5.10 and QT5.15 is different
     Rectangle {
         id: keyboardcontainer
         color: "blue"
@@ -26,7 +26,7 @@ ApplicationWindow {
 
         MouseArea {
             id: touchAkeyboardcontainer
-            anchors.fill: parent //This works now on QT 5.10 as well as QT 5.15
+            anchors.fill: parent
             drag.target: keyboardcontainer
         }
 
@@ -42,14 +42,10 @@ ApplicationWindow {
                 PropertyChanges {
                     target: keyboardcontainer
                     visible: true
-                    x: 200
-                    y: 200
                 }
                 PropertyChanges {
                     target: keyboard
                     visible: true
-                    x:keyboardcontainer.x //done to prevent a offset at opening on QT5.15
-                    y:keyboardcontainer.y //done to prevent a offset at opening on QT5.15
                 }
                 PropertyChanges {
                     target: drawerpopup

--- a/main.qml
+++ b/main.qml
@@ -40,14 +40,14 @@ ApplicationWindow {
                 name: "visible"
                 when: keyboard.active
                 PropertyChanges {
-                    target: keyboard
-                    visible: true
-                }
-                PropertyChanges {
                     target: keyboardcontainer
                     visible: true
                     x: 200
                     y: 200
+                }
+                PropertyChanges {
+                    target: keyboard
+                    visible: true
                 }
                 PropertyChanges {
                     target: drawerpopup

--- a/main.qml
+++ b/main.qml
@@ -48,6 +48,8 @@ ApplicationWindow {
                 PropertyChanges {
                     target: keyboard
                     visible: true
+                    x:keyboardcontainer.x //done to prevent a offset at opening on QT5.15
+                    y:keyboardcontainer.y //done to prevent a offset at opening on QT5.15
                 }
                 PropertyChanges {
                     target: drawerpopup


### PR DESCRIPTION
Move Keyboard by default in the left top corner to prevent a glitch whereby the Keyboard container is offset to the Keyboard before first drag event