### PR TITLE
Ranged state gif

### DIFF
--- a/Gauges/StateGIF.qml
+++ b/Gauges/StateGIF.qml
@@ -66,8 +66,8 @@ Item {
         id : changesize
         color: "darkgrey"
         visible: false
-        width : 200
-        height :320
+        width : 250
+        height :420
         z: 250          //ensure the Menu is always in the foreground
         Drag.active: true
         MouseArea {
@@ -109,7 +109,7 @@ Item {
                 }
             }
             Grid {
-                rows: 4
+                rows: 5
                 columns: 2
                 rowSpacing :5
             Text{

--- a/Gauges/StateGIF.qml
+++ b/Gauges/StateGIF.qml
@@ -12,6 +12,7 @@ Item {
     property string increasedecreaseident
     property string mainvaluename
     property double triggervalue : 0
+    property double triggeroffvalue : 0
     Drag.active: true
     DatasourcesList{id: powertunedatasource}
     Component.onCompleted: {togglemousearea();
@@ -194,6 +195,17 @@ Item {
                 //onTextChanged: triggervalue = triggeronvalue.text
                 font.pixelSize: 12
             }
+         Text{
+                text: "Triggeroff"
+                font.pixelSize: 12
+            }
+            TextField {
+                id: triggerofffvalue
+                width: 140
+                height: 40
+                text: triggeroffvalue
+                font.pixelSize: 12
+            }
             }
             RoundButton{
                 width: parent.width
@@ -207,6 +219,7 @@ Item {
                 font.pixelSize: 15
                 onClicked: {
                     triggervalue = triggeronvalue.text;
+                    triggeroffvalue = triggerofffvalue.text;
                     mainvaluename = powertunedatasource.get(cbxMain.currentIndex).sourcename;
                     changesize.visible = false;
             }
@@ -229,9 +242,8 @@ Item {
         {
           //  //console.log("warning" +mainvaluetextfield.text);
           //  //console.log("Trigger" +mainvaluetextfield.text);
-            if (mainvaluetextfield.text >= triggervalue ){statepictureoff.visible = false,statepictureon.visible = true}
-            if (mainvaluetextfield.text < triggervalue ){statepictureoff.visible = true,statepictureon.visible = false}
-//            else {statepictureoff.visible = true,statepictureon.visible = false};
+         if (mainvaluetextfield.text >= triggervalue && mainvaluetextfield.text <= triggeroffvalue){statepictureoff.visible = false,statepictureon.visible = true}
+          else{statepictureoff.visible = true,statepictureon.visible = false}
 
         }
     }

--- a/Gauges/StateGIF.qml
+++ b/Gauges/StateGIF.qml
@@ -242,9 +242,10 @@ Item {
         {
           //  //console.log("warning" +mainvaluetextfield.text);
           //  //console.log("Trigger" +mainvaluetextfield.text);
-         if (mainvaluetextfield.text >= triggervalue && mainvaluetextfield.text <= triggeroffvalue){statepictureoff.visible = false,statepictureon.visible = true}
-          else{statepictureoff.visible = true,statepictureon.visible = false}
-
+          if (mainvaluetextfield.text >= triggervalue && mainvaluetextfield.text <= triggeroffvalue){statepictureoff.visible = false,statepictureon.visible = true}
+          if (mainvaluetextfield.text < triggervalue){statepictureoff.visible = true,statepictureon.visible = false}
+          if (mainvaluetextfield.text > triggeroffvalue && triggeroffvalue > triggervalue){statepictureoff.visible = true,statepictureon.visible = false}
+          if (mainvaluetextfield.text > triggeroffvalue && triggeroffvalue < triggervalue){statepictureoff.visible = false,statepictureon.visible = true}
         }
     }
     function togglemousearea()

--- a/Gauges/Userdash1.qml
+++ b/Gauges/Userdash1.qml
@@ -819,7 +819,7 @@ Item {
 
             if (userDash.children[i].information === "State GIF")
             {
-                saveDashtofilestring += (userDash.children[i].information+","+userDash.children[i].x+","+userDash.children[i].y+","+userDash.children[i].pictureheight+","+userDash.children[i].mainvaluename+","+userDash.children[i].triggervalue+","+userDash.children[i].statepicturesourceoff+","+userDash.children[i].statepicturesourceon+"\r\n");
+                saveDashtofilestring += (userDash.children[i].information+","+userDash.children[i].x+","+userDash.children[i].y+","+userDash.children[i].pictureheight+","+userDash.children[i].mainvaluename+","+userDash.children[i].triggervalue+","+userDash.children[i].statepicturesourceoff+","+userDash.children[i].statepicturesourceon+","+userDash.children[i].triggeroffvalue+"\r\n");
             }
         }
     }
@@ -925,7 +925,7 @@ Item {
             }
             case "State GIF": {
                 //console.log("Save state");
-                CreateStateGIFScript.createPicture(gaugelist.get(i).x,gaugelist.get(i).y,gaugelist.get(i).height,gaugelist.get(i).source,gaugelist.get(i).trigger,gaugelist.get(i).pictureoff,gaugelist.get(i).pictureon);
+                CreateStateGIFScript.createPicture(gaugelist.get(i).x,gaugelist.get(i).y,gaugelist.get(i).height,gaugelist.get(i).source,gaugelist.get(i).trigger,gaugelist.get(i).pictureoff,gaugelist.get(i).pictureon,gaugelist.get(i).triggeroff);
                 break;
             }
             }
@@ -1126,7 +1126,10 @@ Item {
                                      "source":userDash.children[i].mainvaluename,
                                      "trigger":userDash.children[i].triggervalue,
                                      "pictureoff":userDash.children[i].statepicturesourceoff,
-                                     "pictureon":userDash.children[i].statepicturesourceon})
+                                     "pictureon":userDash.children[i].statepicturesourceon,
+                                     "triggeroff":userDash.children[i].triggeroffvalue,
+
+})
             }
         }
         var datamodel = []

--- a/Gauges/Userdash2.qml
+++ b/Gauges/Userdash2.qml
@@ -809,7 +809,7 @@ Item {
             }
             if (userDash.children[i].information === "State GIF")
             {
-                saveDashtofilestring += (userDash.children[i].information+","+userDash.children[i].x+","+userDash.children[i].y+","+userDash.children[i].pictureheight+","+userDash.children[i].mainvaluename+","+userDash.children[i].triggervalue+","+userDash.children[i].statepicturesourceoff+","+userDash.children[i].statepicturesourceon+"\r\n");
+                saveDashtofilestring += (userDash.children[i].information+","+userDash.children[i].x+","+userDash.children[i].y+","+userDash.children[i].pictureheight+","+userDash.children[i].mainvaluename+","+userDash.children[i].triggervalue+","+userDash.children[i].statepicturesourceoff+","+userDash.children[i].statepicturesourceon+","+userDash.children[i].triggeroffvalue+"\r\n");
             }
         }
     }
@@ -915,7 +915,7 @@ Item {
             }
             case "State GIF": {
                 //console.log("Save state");
-                CreateStateGIFScript.createPicture(gaugelist.get(i).x,gaugelist.get(i).y,gaugelist.get(i).height,gaugelist.get(i).source,gaugelist.get(i).trigger,gaugelist.get(i).pictureoff,gaugelist.get(i).pictureon);
+                CreateStateGIFScript.createPicture(gaugelist.get(i).x,gaugelist.get(i).y,gaugelist.get(i).height,gaugelist.get(i).source,gaugelist.get(i).trigger,gaugelist.get(i).pictureoff,gaugelist.get(i).pictureon,gaugelist.get(i).triggeroff);
                 break;
             }
             }
@@ -1113,7 +1113,9 @@ Item {
                                      "source":userDash.children[i].mainvaluename,
                                      "trigger":userDash.children[i].triggervalue,
                                      "pictureoff":userDash.children[i].statepicturesourceoff,
-                                     "pictureon":userDash.children[i].statepicturesourceon})
+                                     "pictureon":userDash.children[i].statepicturesourceon,
+                                     "triggeroff":userDash.children[i].triggeroffvalue 
+})
             }
         }
         var datamodel = []

--- a/Gauges/Userdash3.qml
+++ b/Gauges/Userdash3.qml
@@ -812,7 +812,7 @@ Item {
             }
             if (userDash.children[i].information === "State GIF")
             {
-                saveDashtofilestring += (userDash.children[i].information+","+userDash.children[i].x+","+userDash.children[i].y+","+userDash.children[i].pictureheight+","+userDash.children[i].mainvaluename+","+userDash.children[i].triggervalue+","+userDash.children[i].statepicturesourceoff+","+userDash.children[i].statepicturesourceon+"\r\n");
+                saveDashtofilestring += (userDash.children[i].information+","+userDash.children[i].x+","+userDash.children[i].y+","+userDash.children[i].pictureheight+","+userDash.children[i].mainvaluename+","+userDash.children[i].triggervalue+","+userDash.children[i].statepicturesourceoff+","+userDash.children[i].statepicturesourceon+","+userDash.children[i].triggeroffvalue+"\r\n");
             }
         }
     }
@@ -918,7 +918,7 @@ Item {
             }
             case "State GIF": {
                 //console.log("Save state");
-                CreateStateGIFScript.createPicture(gaugelist.get(i).x,gaugelist.get(i).y,gaugelist.get(i).height,gaugelist.get(i).source,gaugelist.get(i).trigger,gaugelist.get(i).pictureoff,gaugelist.get(i).pictureon);
+                CreateStateGIFScript.createPicture(gaugelist.get(i).x,gaugelist.get(i).y,gaugelist.get(i).height,gaugelist.get(i).source,gaugelist.get(i).trigger,gaugelist.get(i).pictureoff,gaugelist.get(i).pictureon,gaugelist.get(i).triggeroff);
                 break;
             }
             }
@@ -1116,7 +1116,9 @@ Item {
                                      "source":userDash.children[i].mainvaluename,
                                      "trigger":userDash.children[i].triggervalue,
                                      "pictureoff":userDash.children[i].statepicturesourceoff,
-                                     "pictureon":userDash.children[i].statepicturesourceon})
+                                     "pictureon":userDash.children[i].statepicturesourceon,
+                                     "triggeroff":userDash.children[i].triggeroffvalue
+                                 })
             }
         }
         var datamodel = []

--- a/Gauges/createStateGIF.js
+++ b/Gauges/createStateGIF.js
@@ -1,18 +1,18 @@
 var component;
 var gauge;
-function createPicture(setX,setY,setpictureheight,setValuePropertyMain,settriggervalue,setstatepicturesourceoff,setstatepicturesourceon) {
+function createPicture(setX,setY,setpictureheight,setValuePropertyMain,settriggervalue,setstatepicturesourceoff,setstatepicturesourceon,settriggeroffvalue) {
     component = Qt.createComponent("StateGIF.qml");
     if (component.status === Component.Ready){
         //console.log("creating State Pic")
         //console.log("Create trigger:",settriggervalue);
-        finishCreation(setX,setY,setpictureheight,setValuePropertyMain,settriggervalue,setstatepicturesourceoff,setstatepicturesourceon);
+        finishCreation(setX,setY,setpictureheight,setValuePropertyMain,settriggervalue,setstatepicturesourceoff,setstatepicturesourceon,settriggeroffvalue);
     }
      else
 
         component.statusChanged.connect(finishCreation);
 }
 
-function finishCreation(setX,setY,setpictureheight,setValuePropertyMain,settriggervalue,setstatepicturesourceoff,setstatepicturesourceon) {
+function finishCreation(setX,setY,setpictureheight,setValuePropertyMain,settriggervalue,setstatepicturesourceoff,setstatepicturesourceon,settriggeroffvalue) {
     if (component.status === Component.Ready) {
         gauge = component.createObject(userDash, {
 
@@ -22,7 +22,8 @@ function finishCreation(setX,setY,setpictureheight,setValuePropertyMain,settrigg
                                            "mainvaluename":setValuePropertyMain,
                                            "triggervalue":settriggervalue,
                                            "statepicturesourceoff":setstatepicturesourceoff,
-                                           "statepicturesourceon":setstatepicturesourceon
+                                           "statepicturesourceon":setstatepicturesourceon,
+                                           "triggeroffvalue":settriggeroffvalue
 
                                        });
 


### PR DESCRIPTION
Change to make state gifs ranged, also as example for other state items which could be changed to ranged also. Should be backward compatible with existing dashes as if new triggeroff (aka high trigger of range) is < current existing trigger (aka now the low trigger) it does not make any change to existing behaviour.

Re submitted as was missing extra row and size for new field.