### PR TITLE
Update Squaregauge.qml to have fixed decimal positioning on screen.

### DIFF
--- a/Gauges/Squaregauge.qml
+++ b/Gauges/Squaregauge.qml
@@ -170,7 +170,8 @@ Rectangle {
 
     Text {
         id: mainvaluetextfield
-        anchors.horizontalCenter: parent.horizontalCenter
+        //anchors.horizontalCenter: parent.horizontalCenter
+        anchors.rightMargin: (parent.width / 2) - ((mainvaluetextfield.font.pixelSize * (decimalpoints + 1)) / 2)
         anchors.verticalCenter: parent.verticalCenter
         font.pixelSize: 50
         font.family: valueFonttype


### PR DESCRIPTION
An attempt to keep centre but fix the decimal position in values. This change uses font.pixelSize which Is likely not the correct way, however seems functional in use for setting the starting centre position, then does not recentre the text as the string grows or shrinks. I believe the pixelSize value grows with both fontfamily and size attribute changes, so it seems to generally provide a 'good enough' scaled size even if it is the height of the font.

No tests with languages were done.

The change has a minor effect on the position of text in existing dashes. 

Open for discussion on how to bring this feature which most other  competitors have available to Powertune. 

Some ideas:
Breaking change - minor position change (this or some better code). 
Configurable per dash txt file so all squaregauges are the same for the dash. 
Configurable per squaregauge.