### PR TITLE
Replaces all instances of `endl` with `Qt::endl`

### DIFF
--- a/Apexi.cpp
+++ b/Apexi.cpp
@@ -170,7 +170,7 @@ void Apexi::handleError(QSerialPort::SerialPortError serialPortError)
         if(!mFile.open(QFile::Append | QFile::Text)){
         }
         QTextStream out(&mFile);
-        out << "Serial Error " << (m_serialport->errorString()) <<endl;
+        out << "Serial Error " << (m_serialport->errorString()) <<Qt::endl;
         mFile.close();
         m_dashboard->setSerialStat(m_serialport->errorString());
         
@@ -189,7 +189,7 @@ void Apexi::readyToRead()
     if(!mFile.open(QFile::Append | QFile::Text)){
     }
     QTextStream out(&mFile);
-    out << m_readData.toHex() <<endl;
+    out << m_readData.toHex() <<Qt::endl;
     mFile.close();
     // Test End
   */
@@ -770,7 +770,7 @@ void Apexi::decodeBasic(QByteArray rawmessagedata)
     if(!mFile.open(QFile::Append | QFile::Text)){
     }
     QTextStream out(&mFile);
-    out << rawmessagedata.toHex() <<endl;
+    out << rawmessagedata.toHex() <<Qt::endl;
     mFile.close();
 */    
 }
@@ -870,12 +870,12 @@ void Apexi::writeDashfile(const QString &gauge1,const QString &gauge2,const QStr
 
     {
         QTextStream stream( &file );
-        stream << gauge1 << endl;
-        stream << gauge2 << endl;
-        stream << gauge3 << endl;
-        stream << gauge4 << endl;
-        stream << gauge5 << endl;
-        stream << gauge6 << endl;
+        stream << gauge1 << Qt::endl;
+        stream << gauge2 << Qt::endl;
+        stream << gauge3 << Qt::endl;
+        stream << gauge4 << Qt::endl;
+        stream << gauge5 << Qt::endl;
+        stream << gauge6 << Qt::endl;
     }
 
     QString filename2="/home/pi/UserDashboards/UserDashApexi.txt";
@@ -884,12 +884,12 @@ void Apexi::writeDashfile(const QString &gauge1,const QString &gauge2,const QStr
 
     {
         QTextStream stream( &file2 );
-        stream << gauge1 << endl;
-        stream << gauge2 << endl;
-        stream << gauge3 << endl;
-        stream << gauge4 << endl;
-        stream << gauge5 << endl;
-        stream << gauge6 << endl;
+        stream << gauge1 << Qt::endl;
+        stream << gauge2 << Qt::endl;
+        stream << gauge3 << Qt::endl;
+        stream << gauge4 << Qt::endl;
+        stream << gauge5 << Qt::endl;
+        stream << gauge6 << Qt::endl;
     }
 
 

--- a/connect.cpp
+++ b/connect.cpp
@@ -141,7 +141,7 @@ void Connect::saveDashtoFile(const QString &filename,const QString &dashstring)
     if ( file.open(QIODevice::ReadWrite) )
     {
         QTextStream stream( &file );
-        stream << fixformat << endl;
+        stream << fixformat << Qt::endl;
     }
     file.close();
 }
@@ -932,23 +932,23 @@ void Connect::daemonstartup(const int &daemon)
         mFile.open(QIODevice::ReadWrite | QIODevice::Truncate | QIODevice::Text);
         QTextStream out(&mFile);
         out << "#!/bin/sh"
-            << endl
+            << Qt::endl
             << "sudo ifdown can0"
-            << endl
+            << Qt::endl
             << "sudo ifup can0"
-            << endl
+            << Qt::endl
             << "#PLMS Consult Cable drivers"
-            << endl
+            << Qt::endl
             << "sudo modprobe ftdi_sio"
-            << endl
+            << Qt::endl
             << "sudo sh -c 'echo \"0403 c7d9\" > /sys/bus/usb-serial/drivers/ftdi_sio/new_id'"
-            << endl
+            << Qt::endl
             << "sleep 1.5"
-            << endl
+            << Qt::endl
             << "cd /home/pi/daemons"
-            << endl
+            << Qt::endl
             << daemonstart
-            << endl;
+            << Qt::endl;
         mFile.close();
     }
     else
@@ -957,15 +957,15 @@ void Connect::daemonstartup(const int &daemon)
         mFile.open(QIODevice::ReadWrite | QIODevice::Truncate | QIODevice::Text);
         QTextStream out(&mFile);
         out << "#!/bin/sh"
-            << endl
+            << Qt::endl
             << "sudo ifdown can0"
-            << endl
+            << Qt::endl
             << "sudo ifup can0"
-            << endl
+            << Qt::endl
             << "cd /home/pi/daemons"
-            << endl
+            << Qt::endl
             << daemonstart
-            << endl;
+            << Qt::endl;
         mFile.close();
     }
 
@@ -997,23 +997,23 @@ void Connect::canbitratesetup(const int &cansetting)
     {
         QTextStream out(&mFile);
         out << "# interfaces(5) file used by ifup(8) and ifdown(8)"
-            << endl
+            << Qt::endl
             << "# Please note that this file is written to be used with dhcpcd"
-            << endl
+            << Qt::endl
             << "# For static IP, consult /etc/dhcpcd.conf and 'man dhcpcd.conf'"
-            << endl
+            << Qt::endl
             << "# Include files from /etc/network/interfaces.d:"
-            << endl
+            << Qt::endl
             << "source-directory /etc/network/interfaces.d"
-            << endl
+            << Qt::endl
             << "#Automatically start CAN Interface"
-            << endl
+            << Qt::endl
             << "auto can0"
-            << endl
+            << Qt::endl
             << "iface can0 can static"
-            << endl
+            << Qt::endl
             << "bitrate " << canbitrate
-            << endl;
+            << Qt::endl;
     }
     else
     {
@@ -1021,51 +1021,51 @@ void Connect::canbitratesetup(const int &cansetting)
 
         QTextStream out(&mFile);
         out << "#!/bin/sh"
-            << endl
+            << Qt::endl
             << "# /etc/network/interfaces -- configuration file for ifup(8), ifdown(8)"
-            << endl
+            << Qt::endl
             <<"# The loopback interface"
-              << endl
+              << Qt::endl
             <<"auto lo"
-             << endl
+             << Qt::endl
             <<"iface lo inet loopback"
-            << endl
+            << Qt::endl
             <<"# Wireless interfaces"
-            << endl
+            << Qt::endl
             << "auto wlan0"
-            << endl
+            << Qt::endl
             <<"    iface wlan0 inet dhcp"
-            << endl
+            << Qt::endl
             <<"    hostname PowerTuneDigital"
-            << endl
+            << Qt::endl
             <<"    wireless_mode managed"
-            << endl
+            << Qt::endl
             << "   wireless_essid any"
-            << endl
+            << Qt::endl
             << "   wpa-driver wext"
-            << endl
+            << Qt::endl
             <<"    wpa-conf /etc/wpa_supplicant.conf"
-            << endl
+            << Qt::endl
             <<"    iface atml0 inet dhcp"
-            << endl
+            << Qt::endl
             <<"# Wired or wireless interfaces"
-            << endl
+            << Qt::endl
             <<"auto eth0"
-            << endl
+            << Qt::endl
             <<"    iface eth0 inet dhcp"
-            << endl
+            << Qt::endl
             <<"# Automatically start CAN Interface"
-            << endl
+            << Qt::endl
             <<"    auto can0"
-            << endl
+            << Qt::endl
             <<"   iface can0 inet manual"
-            << endl
+            << Qt::endl
             <<"    pre-up /sbin/ip link set can0 type can bitrate "<< canbitrate
-            << endl
+            << Qt::endl
             <<"    up /sbin/ifconfig can0 up"
-            << endl
+            << Qt::endl
             <<"    down /sbin/ifconfig can0 down"
-            << endl;
+            << Qt::endl;
 
     }
 

--- a/datalogger.cpp
+++ b/datalogger.cpp
@@ -180,7 +180,7 @@ void datalogger::updateLog()
                 << m_dashboard->EXDigitalInput6()  << ","
                 << m_dashboard->EXDigitalInput7()  << ","
                 << m_dashboard->EXDigitalInput8()  << ","
-                << endl;
+                << Qt::endl;
             mFile.close();
             break;
             case 1: ////Link ECU Generic CAN
@@ -249,7 +249,7 @@ void datalogger::updateLog()
                     << m_dashboard->EXDigitalInput6()  << ","
                     << m_dashboard->EXDigitalInput7()  << ","
                     << m_dashboard->EXDigitalInput8()  << ","
-                    << endl;
+                    << Qt::endl;
             mFile.close();
             break;
             case 2: ////Toyota86 BRZ FRS
@@ -294,7 +294,7 @@ void datalogger::updateLog()
                                    << m_dashboard->EXDigitalInput6()  << ","
                                    << m_dashboard->EXDigitalInput7()  << ","
                                    << m_dashboard->EXDigitalInput8()  << ","
-                                   << endl;
+                                   << Qt::endl;
                 mFile.close();
                 break;
             case 5: ////ECU MASTERS EMU CAN
@@ -355,7 +355,7 @@ void datalogger::updateLog()
                                    << m_dashboard->EXDigitalInput6()  << ","
                                    << m_dashboard->EXDigitalInput7()  << ","
                                    << m_dashboard->EXDigitalInput8()  << ","
-                                   << endl;
+                                   << Qt::endl;
                 mFile.close();
                 break;
             case 6: ////GR YARIS
@@ -405,7 +405,7 @@ void datalogger::updateLog()
                                    << m_dashboard->EXDigitalInput6()  << ","
                                    << m_dashboard->EXDigitalInput7()  << ","
                                    << m_dashboard->EXDigitalInput8()  << ","
-                                   << endl;
+                                   << Qt::endl;
                 mFile.close();
                 break;
         }
@@ -552,7 +552,7 @@ QTextStream out(&mFile);
                     << "EX Digitial 6"  << ","
                     << "EX Digitial 7"  << ","
                     << "EX Digitial 8"  << ","
-                    << endl;
+                    << Qt::endl;
             mFile.close();
                 break;
             case 1: ////Link ECU Generic CAN
@@ -621,7 +621,7 @@ QTextStream out(&mFile);
                     << "EX Digitial 6"  << ","
                     << "EX Digitial 7"  << ","
                     << "EX Digitial 8"  << ","
-                    << endl;
+                    << Qt::endl;
             mFile.close();
                 break;
 
@@ -667,7 +667,7 @@ QTextStream out(&mFile);
                            << "EX Digitial 6"  << ","
                            << "EX Digitial 7"  << ","
                            << "EX Digitial 8"  << ","
-                              << endl;
+                              << Qt::endl;
                               mFile.close();
                                   break;
 
@@ -730,7 +730,7 @@ QTextStream out(&mFile);
                            << "EX Digitial 6"  << ","
                            << "EX Digitial 7"  << ","
                            << "EX Digitial 8"  << ","
-                              << endl;
+                              << Qt::endl;
                               mFile.close();
                                   break;
             case 6: ////GR YARIS
@@ -779,7 +779,7 @@ QTextStream out(&mFile);
                            << "EX Digitial 6"  << ","
                            << "EX Digitial 7"  << ","
                            << "EX Digitial 8"  << ","
-                           << endl;
+                           << Qt::endl;
                 mFile.close();
                 break;
 
@@ -787,5 +787,3 @@ QTextStream out(&mFile);
         }
     }
 }
-
-

--- a/wifiscanner.cpp
+++ b/wifiscanner.cpp
@@ -144,7 +144,7 @@ void WifiScanner::setwifi(const QString &country,const QString &ssid1,const QStr
                        // << "ssid="<< "\"" << ssid2 << "\"" << "\r\n"
                        // << "psk=" << "\"" << psk2 << "\"" << "\r\n"
                        // << "}" << "\r\n"
-                    << endl;
+                    << Qt::endl;
             file.close();
         }
         else
@@ -163,9 +163,8 @@ void WifiScanner::setwifi(const QString &country,const QString &ssid1,const QStr
                    // << "ssid="<< "\"" << ssid2 << "\"" << "\r\n"
                    // << "psk=" << "\"" << psk2 << "\"" << "\r\n"
                    // << "}" << "\r\n"
-                << endl;
+                << Qt::endl;
         file.close();
         }
     }
 }
-


### PR DESCRIPTION
This commit replaces all instances of `endl` with `Qt::endl` across the codebase. The update is in line with the deprecation warnings introduced in Qt 5.14 and ensures compatibility with future versions of Qt.

Right now, compiling Powertune on more modern version of QT (like the LTS 5.15) generates over 50 warnings.

Reasons for switching to Qt::endl:
1. **Consistency**: `Qt::endl` aligns with Qt naming conventions and integrates better with the Qt framework.
2. **Performance**: Unlike `endl`, which always flushes the output stream, `Qt::endl` provides better control over when the stream is flushed. This can improve performance, especially in scenarios where frequent flushing is unnecessary and can be managed explicitly.
3. **Future-Proofing**: Adhering to the latest standards in Qt ensures easier maintenance and fewer modifications during future upgrades.

The Qt documentation for QTextStream explains that endl is a manipulator that inserts a newline character into the stream and flushes the stream. This automatic flushing can lead to performance overhead when used in loops or high-frequency logging. Switching to Qt::endl allows developers to control flushing more explicitly, which can optimize performance by reducing unnecessary flushes.